### PR TITLE
Fix mobile hamburger menu display and functionality

### DIFF
--- a/frontend/src/components/layout/Layout.jsx
+++ b/frontend/src/components/layout/Layout.jsx
@@ -165,6 +165,9 @@ const Layout = () => {
             })}
           </nav>
 
+          {/* Spacer pushes right-side content (incl. hamburger on mobile) */}
+          <div className="flex-1" />
+
           {/* Mobile Menu Button */}
           <HamburgerButton isOpen={mobileMenuOpen} onClick={toggleMobileMenu} />
 

--- a/frontend/src/components/layout/MobileMenu.jsx
+++ b/frontend/src/components/layout/MobileMenu.jsx
@@ -34,10 +34,9 @@ const MobileMenu = ({
 
   // Close menu on route change
   useEffect(() => {
-    if (isOpen) {
-      onClose();
-    }
-  }, [location.pathname, isOpen, onClose]);
+    onClose();
+    // Intentionally only depend on pathname to avoid closing immediately on open
+  }, [location.pathname]);
 
   // Handle escape key
   useEffect(() => {


### PR DESCRIPTION
Fix mobile hamburger menu not opening and align it to the right.

The menu was closing immediately due to an `isOpen` dependency in the `useEffect` hook, which was removed to allow proper toggling. A flex spacer was added to `Layout.jsx` to push the hamburger button to the right.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2344118-63ba-4840-a290-20f32b54eb8c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f2344118-63ba-4840-a290-20f32b54eb8c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

