### PR TITLE
Fix german language string display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,12 @@ jspm_packages/
 .cache/
 public
 
+# Allow locale assets under frontend/public while keeping other public content ignored
+!frontend/public/
+frontend/public/*
+!frontend/public/locales/
+!frontend/public/locales/**
+
 # Vuepress build output
 .vuepress/dist
 

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -1,0 +1,80 @@
+{
+  "app": {
+    "title": "Tischtennis Liga"
+  },
+  "language": {
+    "english": "Englisch",
+    "german": "Deutsch"
+  },
+  "nav": {
+    "dashboard": "Übersicht",
+    "leagues": "Ligen",
+    "matches": "Spiele",
+    "admin": "Admin",
+    "notifications": "Benachrichtigungen",
+    "profile": "Profil",
+    "settings": "Einstellungen",
+    "logout": "Abmelden"
+  },
+  "welcome": "Willkommen, {{name}}!",
+  "dashboard": {
+    "subtitle": "Behalte Spiele, Ligen und Wertung im Blick."
+  },
+  "stats": {
+    "leagues": "Ligen: {{count}}",
+    "matches": "Spiele: {{count}}",
+    "wins": "Siege: {{wins}} ({{rate}}%)"
+  },
+  "notifications": {
+    "title": "Benachrichtigungen",
+    "none": "Noch nichts hier",
+    "counts": "{{unread}} ungelesen von {{total}} insgesamt",
+    "loadError": "Benachrichtigungen konnten nicht geladen werden",
+    "markReadError": "Konnte nicht als gelesen markieren",
+    "markAllError": "Konnte nicht alle als gelesen markieren",
+    "missingLeague": "Fehlender Liga‑Verweis",
+    "joinedLeague": "Liga beigetreten",
+    "acceptError": "Einladung konnte nicht angenommen werden",
+    "denyError": "Einladung konnte nicht abgelehnt werden",
+    "deleted": "Benachrichtigung gelöscht",
+    "deleteError": "Benachrichtigung konnte nicht gelöscht werden",
+    "inviteHandled": "Einladung erledigt"
+  },
+  "cta": {
+    "recordMatch": "Spiel eintragen",
+    "browseLeagues": "Ligen durchsuchen",
+    "viewProfile": "Profil ansehen"
+  },
+  "actions": {
+    "markAllRead": "Alle als gelesen markieren",
+    "read": "Lesen",
+    "delete": "Löschen",
+    "accept": "Annehmen",
+    "reject": "Ablehnen"
+  },
+  "common": {
+    "all": "Alle",
+    "unread": "Ungelesen",
+    "loading": "Lädt…",
+    "submitting": "Senden…",
+    "reset": "Zurücksetzen"
+  },
+  "table": {
+    "when": "Wann",
+    "league": "Liga",
+    "players": "Spieler",
+    "result": "Ergebnis",
+    "actions": "Aktionen"
+  },
+  "status": {
+    "marking": "Markiere…",
+    "deleting": "Lösche…",
+    "joining": "Beitreten…",
+    "creating": "Erstelle…"
+  },
+  "matchDetail": {
+    "viewLeague": "Liga anzeigen",
+    "gameType": "Spieltyp"
+  }
+}
+

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -1,0 +1,80 @@
+{
+  "app": {
+    "title": "Table Tennis League"
+  },
+  "language": {
+    "english": "English",
+    "german": "German"
+  },
+  "nav": {
+    "dashboard": "Dashboard",
+    "leagues": "Leagues",
+    "matches": "Matches",
+    "admin": "Admin",
+    "notifications": "Notifications",
+    "profile": "Profile",
+    "settings": "Settings",
+    "logout": "Log out"
+  },
+  "welcome": "Welcome, {{name}}!",
+  "dashboard": {
+    "subtitle": "Track your matches, leagues, and rating at a glance."
+  },
+  "stats": {
+    "leagues": "Leagues: {{count}}",
+    "matches": "Matches: {{count}}",
+    "wins": "Wins: {{wins}} ({{rate}}%)"
+  },
+  "notifications": {
+    "title": "Notifications",
+    "none": "Nothing here yet",
+    "counts": "{{unread}} unread of {{total}} total",
+    "loadError": "Failed to load notifications",
+    "markReadError": "Failed to mark as read",
+    "markAllError": "Failed to mark all as read",
+    "missingLeague": "Missing league reference",
+    "joinedLeague": "Joined league",
+    "acceptError": "Failed to accept invite",
+    "denyError": "Failed to deny invite",
+    "deleted": "Notification deleted",
+    "deleteError": "Failed to delete notification",
+    "inviteHandled": "Invite handled"
+  },
+  "cta": {
+    "recordMatch": "Record match",
+    "browseLeagues": "Browse leagues",
+    "viewProfile": "View profile"
+  },
+  "actions": {
+    "markAllRead": "Mark all read",
+    "read": "Read",
+    "delete": "Delete",
+    "accept": "Accept",
+    "reject": "Reject"
+  },
+  "common": {
+    "all": "All",
+    "unread": "Unread",
+    "loading": "Loading…",
+    "submitting": "Submitting…",
+    "reset": "Reset"
+  },
+  "table": {
+    "when": "When",
+    "league": "League",
+    "players": "Players",
+    "result": "Result",
+    "actions": "Actions"
+  },
+  "status": {
+    "marking": "Marking…",
+    "deleting": "Deleting…",
+    "joining": "Joining…",
+    "creating": "Creating…"
+  },
+  "matchDetail": {
+    "viewLeague": "View league",
+    "gameType": "Game type"
+  }
+}
+


### PR DESCRIPTION
Add missing `common.json` locale files for English and German to resolve raw translation key display.

---
<a href="https://cursor.com/background-agent?bcId=bc-96659b36-8e8c-42f0-8546-0f7a56301051">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-96659b36-8e8c-42f0-8546-0f7a56301051">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

