### PR TITLE
Pre-launch checks and steps

### DIFF
--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -61,7 +61,7 @@ async function requireLeagueAdmin(req, res, next) {
         
         // Check if user is league admin
         const membership = await database.get(
-            'SELECT is_admin FROM league_members WHERE league_id = ? AND user_id = ?',
+            'SELECT is_admin FROM league_roster WHERE league_id = ? AND user_id = ?',
             [leagueId, req.user.id]
         );
         

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -87,9 +87,9 @@ const validateMatchCreation = [
     body('league_id')
         .isInt({ min: 1 })
         .withMessage('Valid league ID is required'),
-    body('player2_id')
+    body('player2_roster_id')
         .isInt({ min: 1 })
-        .withMessage('Valid opponent ID is required'),
+        .withMessage('Valid opponent roster ID is required'),
     body('player1_sets_won')
         .isInt({ min: 0, max: 4 })
         .withMessage('Player 1 sets won must be between 0 and 4'),

--- a/backend/src/routes/badges.js
+++ b/backend/src/routes/badges.js
@@ -299,7 +299,7 @@ router.post('/users/:id/badges', authenticateToken, validateId, async (req, res)
             }
 
             const membership = await database.get(
-                'SELECT is_admin FROM league_members WHERE league_id = ? AND user_id = ?',
+                'SELECT is_admin FROM league_roster WHERE league_id = ? AND user_id = ?',
                 [leagueIdInt, req.user.id]
             );
 

--- a/backend/src/routes/badges.js
+++ b/backend/src/routes/badges.js
@@ -319,7 +319,7 @@ router.post('/users/:id/badges', authenticateToken, requireAdmin, validateId, as
             
             // Validate user is a member of the league
             const membership = await database.get(
-                'SELECT id FROM league_members WHERE league_id = ? AND user_id = ?',
+                'SELECT id FROM league_roster WHERE league_id = ? AND user_id = ?',
                 [league_id, userId]
             );
             

--- a/docs/ROSTER_MODEL.md
+++ b/docs/ROSTER_MODEL.md
@@ -1,0 +1,120 @@
+# Roster-based league membership (placeholders + matches/ELO)
+
+This project now supports **league roster entries** that can exist **without** a user account (a “placeholder”), and can later be assigned to a real `users` row. Matches and ELO are tracked against **roster IDs**, not user IDs.
+
+## Why this exists
+
+For child leagues, you may want to:
+
+- Pre-create a league roster with simple names (no login / no email yet)
+- Record matches and ELO immediately
+- Later let a child/parent create an account and **assign** that account to an existing roster entry
+
+## Database model (high level)
+
+### `league_roster` (new)
+
+Each row is a participant slot inside a league.
+
+- **`id`**: roster ID (primary key)
+- **`league_id`**: league (FK)
+- **`user_id`**: optional link to `users.id` (nullable)
+  - `NULL` means **placeholder**
+  - non-null means **assigned**
+- **`display_name`**: the league-facing name (required)
+  - When a placeholder is assigned to a user, this name remains the display name (so the placeholder name “wins”)
+- **`current_elo`**: the league ELO for this roster entry
+- **`is_admin`**: whether this roster entry’s user is a league admin (only meaningful when `user_id` is set)
+- **`joined_at`**
+
+### `matches` (updated)
+
+Matches now reference roster entries:
+
+- **`player1_roster_id`**
+- **`player2_roster_id`**
+- **`winner_roster_id`**
+
+Legacy columns `player1_id` / `player2_id` / `winner_id` still exist for compatibility, but are **nullable** and should be treated as **non-canonical** (roster IDs are canonical).
+
+### `elo_history` (updated)
+
+ELO history now supports roster entries:
+
+- **`roster_id`** (nullable, but written for roster-based flows)
+- **`user_id`** is now nullable (placeholders have no user)
+
+For real users, endpoints that show “user ELO history” use `elo_history.user_id` + the league filter.
+
+## API flows
+
+### Create placeholder roster member (league admin)
+
+`POST /api/leagues/:id/roster`
+
+Body:
+
+```json
+{ "display_name": "Max" }
+```
+
+Creates a roster entry with `user_id = null`.
+
+### Assign an account to a roster entry (league admin)
+
+`POST /api/leagues/:id/roster/:rosterId/assign`
+
+Body:
+
+```json
+{ "user_id": 123 }
+```
+
+Rules:
+
+- Roster entry must exist and be unassigned (`user_id` is null)
+- The user must exist
+- The user must not already be assigned to another roster entry in the same league
+- **`display_name` is not changed** on assignment
+
+### Record match (authenticated user)
+
+`POST /api/matches`
+
+Body (important fields):
+
+```json
+{
+  "league_id": 1,
+  "player2_roster_id": 55,
+  "player1_sets_won": 2,
+  "player2_sets_won": 1,
+  "player1_points_total": 33,
+  "player2_points_total": 31,
+  "game_type": "best_of_3"
+}
+```
+
+Notes:
+
+- The server finds the caller’s roster entry in that league for player 1.
+- `player2_roster_id` can point to a placeholder (no account).
+- If the opponent roster entry has `user_id`, they receive a notification; placeholders do not.
+
+## Migration / compatibility notes
+
+On startup, the backend initializes/migrates:
+
+- Creates `league_roster` if missing
+- Adds roster columns to `matches` and `elo_history` if missing
+- Makes legacy match/user columns nullable (needed for placeholder-vs-user matches)
+- Migrates legacy `league_members` into `league_roster` (one roster entry per user per league)
+- Backfills roster IDs into existing matches/ELO history where possible
+
+## Next steps (optional)
+
+- Add UI in the admin panel to:
+  - create placeholders
+  - assign a user to a roster entry
+- Allow **public viewing** of leagues/leaderboards without auth (careful with child privacy and data exposure).
+

--- a/frontend/src/pages/LeagueDetailPage.jsx
+++ b/frontend/src/pages/LeagueDetailPage.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState, useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { leaguesAPI, matchesAPI } from '@/services/api';
-import { badgesAPI } from '@/services/api';
+import { leaguesAPI, matchesAPI, badgesAPI } from '@/services/api';
 import LoadingSpinner from '@/components/ui/LoadingSpinner';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -667,7 +666,7 @@ const LeagueDetailPage = () => {
                   <div className="sm:hidden space-y-2">
                     {leaderboard.map((p) => (
                       <div
-                        key={p.id}
+                        key={p.roster_id}
                         className="rounded-lg border border-gray-800 bg-gray-900/30 p-2"
                       >
                         <div className="flex items-start gap-2 min-w-0">
@@ -683,13 +682,19 @@ const LeagueDetailPage = () => {
 
                           <div className="min-w-0 flex-1">
                             <div className="flex items-center justify-between gap-2 min-w-0">
-                              <Link
-                                to={`/profile/${p.username}`}
-                                className="min-w-0 truncate text-blue-400 hover:text-blue-300 font-medium text-sm"
-                                title={p.username}
-                              >
-                                {p.username}
-                              </Link>
+                              {p.username ? (
+                                <Link
+                                  to={`/profile/${p.username}`}
+                                  className="min-w-0 truncate text-blue-400 hover:text-blue-300 font-medium text-sm"
+                                  title={p.display_name || p.username}
+                                >
+                                  {p.display_name || p.username}
+                                </Link>
+                              ) : (
+                                <span className="min-w-0 truncate text-gray-200 font-medium text-sm" title={p.display_name}>
+                                  {p.display_name}
+                                </span>
+                              )}
                               <div className="shrink-0 text-sm text-gray-200 font-semibold tabular-nums whitespace-nowrap">
                                 {t('leagues.elo')}: {p.current_elo}
                               </div>
@@ -704,7 +709,11 @@ const LeagueDetailPage = () => {
                                 <span>{p.win_rate}%</span>
                               </div>
                               <div className="shrink-0">
-                                <EloSparkline userId={p.id} leagueId={id} width={72} height={14} points={15} />
+                                {p.user_id ? (
+                                  <EloSparkline userId={p.user_id} leagueId={id} width={72} height={14} points={15} />
+                                ) : (
+                                  <span className="text-xs text-gray-500">—</span>
+                                )}
                               </div>
                             </div>
 
@@ -772,6 +781,7 @@ const LeagueDetailPage = () => {
                               ) : (
                                 <span className="text-xs text-gray-500">—</span>
                               )}
+                            </td>
                             <td className="px-3 py-2 text-gray-200 tabular-nums whitespace-nowrap align-middle text-xs">
                               <span className="text-gray-300">{p.matches_won}/{p.matches_played - p.matches_won}</span>
                               <span className="text-gray-600"> • </span>
@@ -971,9 +981,9 @@ const LeagueDetailPage = () => {
                       <SelectValue placeholder="Select member" />
                     </SelectTrigger>
                     <SelectContent>
-                      {members.map((m) => (
-                        <SelectItem key={m.id} value={String(m.id)}>
-                          {m.username}
+                      {members.filter((m) => m.user_id).map((m) => (
+                        <SelectItem key={m.user_id} value={String(m.user_id)}>
+                          {m.display_name || m.username}
                         </SelectItem>
                       ))}
                     </SelectContent>

--- a/frontend/src/pages/MatchDetailPage.jsx
+++ b/frontend/src/pages/MatchDetailPage.jsx
@@ -128,7 +128,7 @@ export default function MatchDetailPage() {
   const canEdit = useMemo(() => {
     if (!match || match.is_accepted) return false;
     if (!me?.id) return false;
-    return me.id === match.player1_id || me.id === match.player2_id;
+    return me.id === match.player1_user_id || me.id === match.player2_user_id;
   }, [match, me?.id]);
 
   const load = async () => {
@@ -184,17 +184,17 @@ export default function MatchDetailPage() {
         try {
           const meId = me?.id;
           if (!meId) return setEloPreview(null);
-          const otherId = meId === match.player1_id ? match.player2_id : match.player1_id;
+          const otherRosterId = meId === match.player1_user_id ? match.player2_roster_id : match.player1_roster_id;
           const payload = {
             league_id: match.league_id,
-            player2_id: otherId,
+            player2_roster_id: otherRosterId,
             player1_sets_won: values.player1_sets_won,
             player2_sets_won: values.player2_sets_won,
             player1_points_total: Number.isFinite(+values.player1_points_total) ? +values.player1_points_total : 0,
             player2_points_total: Number.isFinite(+values.player2_points_total) ? +values.player2_points_total : 0,
           };
           if (
-            payload.league_id && payload.player2_id &&
+            payload.league_id && payload.player2_roster_id &&
             payload.player1_sets_won != null && payload.player2_sets_won != null
           ) {
             const { data } = await matchesAPI.previewElo(payload);
@@ -202,7 +202,7 @@ export default function MatchDetailPage() {
           } else {
             setEloPreview(null);
           }
-        } catch (e) {
+        } catch {
           setEloPreview(null);
         }
       }, 300);
@@ -247,6 +247,9 @@ export default function MatchDetailPage() {
   );
   if (!match) return null;
 
+  const p1Name = match.player1_display_name || match.player1_username || 'Player 1';
+  const p2Name = match.player2_display_name || match.player2_username || 'Player 2';
+
   const deltaP1 = match.player1_elo_after != null && match.player1_elo_before != null ? match.player1_elo_after - match.player1_elo_before : null;
   const deltaP2 = match.player2_elo_after != null && match.player2_elo_before != null ? match.player2_elo_after - match.player2_elo_before : null;
 
@@ -259,7 +262,19 @@ export default function MatchDetailPage() {
 
       <Card className="mb-4">
         <CardHeader>
-          <CardTitle><Link to={`/profile/${match.player1_username}`} className="underline hover:no-underline">{match.player1_username}</Link> {t('common.vs')} <Link to={`/profile/${match.player2_username}`} className="underline hover:no-underline">{match.player2_username}</Link></CardTitle>
+          <CardTitle>
+            {match.player1_username ? (
+              <Link to={`/profile/${match.player1_username}`} className="underline hover:no-underline">{p1Name}</Link>
+            ) : (
+              <span>{p1Name}</span>
+            )}{' '}
+            {t('common.vs')}{' '}
+            {match.player2_username ? (
+              <Link to={`/profile/${match.player2_username}`} className="underline hover:no-underline">{p2Name}</Link>
+            ) : (
+              <span>{p2Name}</span>
+            )}
+          </CardTitle>
           <CardDescription>
             {match.played_at ? `${t('matchDetail.played')}: ${format(new Date(match.played_at), 'PP p')}` : `${t('matchDetail.created')}: ${format(new Date(match.created_at), 'PP p')}`}
           </CardDescription>
@@ -283,7 +298,7 @@ export default function MatchDetailPage() {
           {match.is_accepted && (
             <div className="grid gap-1 md:grid-cols-2">
               <div>
-                <div className="text-muted-foreground">{match.player1_username} ELO</div>
+                <div className="text-muted-foreground">{p1Name} ELO</div>
                 <div>
                   {match.player1_elo_before} → {match.player1_elo_after} {deltaP1 != null && (
                     <span className={deltaP1 > 0 ? 'text-green-600' : deltaP1 < 0 ? 'text-red-600' : 'text-muted-foreground'}>
@@ -293,7 +308,7 @@ export default function MatchDetailPage() {
                 </div>
               </div>
               <div>
-                <div className="text-muted-foreground">{match.player2_username} ELO</div>
+                <div className="text-muted-foreground">{p2Name} ELO</div>
                 <div>
                   {match.player2_elo_before} → {match.player2_elo_after} {deltaP2 != null && (
                     <span className={deltaP2 > 0 ? 'text-green-600' : deltaP2 < 0 ? 'text-red-600' : 'text-muted-foreground'}>
@@ -348,7 +363,7 @@ export default function MatchDetailPage() {
                   control={form.control}
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>{match.player1_username} sets won</FormLabel>
+                      <FormLabel>{p1Name} sets won</FormLabel>
                       <FormControl>
                         <Input type="number" min={0} max={4} {...field} onChange={(e) => field.onChange(Number(e.target.value))} disabled={!canEdit} />
                       </FormControl>
@@ -361,7 +376,7 @@ export default function MatchDetailPage() {
                   control={form.control}
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>{match.player2_username} sets won</FormLabel>
+                      <FormLabel>{p2Name} sets won</FormLabel>
                       <FormControl>
                         <Input type="number" min={0} max={4} {...field} onChange={(e) => field.onChange(Number(e.target.value))} disabled={!canEdit} />
                       </FormControl>
@@ -387,7 +402,7 @@ export default function MatchDetailPage() {
                             setSetScores((arr) => arr.map((it, i) => (i === idx ? { ...it, p1: Number.isFinite(v) ? v : 0 } : it)));
                           }}
                           className="w-14 h-8 px-2 text-sm"
-                          aria-label={`${match.player1_username} points in set ${idx + 1}`}
+                          aria-label={`${p1Name} points in set ${idx + 1}`}
                           style={getSetClosenessStyle(s.p1, s.p2)}
                         />
                         <span className="text-sm">:</span>
@@ -400,7 +415,7 @@ export default function MatchDetailPage() {
                             setSetScores((arr) => arr.map((it, i) => (i === idx ? { ...it, p2: Number.isFinite(v) ? v : 0 } : it)));
                           }}
                           className="w-14 h-8 px-2 text-sm"
-                          aria-label={`${match.player2_username} points in set ${idx + 1}`}
+                          aria-label={`${p2Name} points in set ${idx + 1}`}
                           style={getSetClosenessStyle(s.p1, s.p2)}
                         />
                       </div>
@@ -427,7 +442,7 @@ export default function MatchDetailPage() {
                   control={form.control}
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>{match.player1_username} total points (auto)</FormLabel>
+                      <FormLabel>{p1Name} total points (auto)</FormLabel>
                       <FormControl>
                         <Input type="number" min={0} {...field} readOnly disabled />
                       </FormControl>
@@ -441,7 +456,7 @@ export default function MatchDetailPage() {
                   control={form.control}
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>{match.player2_username} total points (auto)</FormLabel>
+                      <FormLabel>{p2Name} total points (auto)</FormLabel>
                       <FormControl>
                         <Input type="number" min={0} {...field} readOnly disabled />
                       </FormControl>
@@ -460,7 +475,7 @@ export default function MatchDetailPage() {
                   ) : (
                     <div className="grid gap-2 md:grid-cols-2">
                       <div>
-                        <div className="text-muted-foreground">{match.player1_username}</div>
+                        <div className="text-muted-foreground">{p1Name}</div>
                         <div>
                           {eloPreview.current_elos?.player1} → {eloPreview.new_elos?.player1}{' '}
                           <span className={(() => {
@@ -472,7 +487,7 @@ export default function MatchDetailPage() {
                         </div>
                       </div>
                       <div>
-                        <div className="text-muted-foreground">{match.player2_username}</div>
+                        <div className="text-muted-foreground">{p2Name}</div>
                         <div>
                           {eloPreview.current_elos?.player2} → {eloPreview.new_elos?.player2}{' '}
                           <span className={(() => {

--- a/frontend/src/pages/MatchesPage.jsx
+++ b/frontend/src/pages/MatchesPage.jsx
@@ -60,22 +60,24 @@ export default function MatchesPage() {
   const canPrev = page > 1;
   const canNext = page < pages;
 
-  const youVsLabel = (m) => {
-    const myUsername = me?.username;
-    if (!myUsername) return `${m.player1_username} vs ${m.player2_username}`;
-    if (m.player1_username === myUsername) return `You vs ${m.player2_username}`;
-    if (m.player2_username === myUsername) return `${m.player1_username} vs You`;
-    return `${m.player1_username} vs ${m.player2_username}`;
+  const _youVsLabel = (m) => {
+    const meId = me?.id;
+    const p1 = m.player1_display_name || m.player1_username || 'Player 1';
+    const p2 = m.player2_display_name || m.player2_username || 'Player 2';
+    if (!meId) return `${p1} vs ${p2}`;
+    if (m.player1_user_id === meId) return `You vs ${p2}`;
+    if (m.player2_user_id === meId) return `${p1} vs You`;
+    return `${p1} vs ${p2}`;
   };
 
   const yourEloDelta = (m) => {
     if (!m.is_accepted) return null;
-    const myUsername = me?.username;
-    if (!myUsername) return null;
-    if (m.player1_username === myUsername && m.player1_elo_after != null && m.player1_elo_before != null) {
+    const meId = me?.id;
+    if (!meId) return null;
+    if (m.player1_user_id === meId && m.player1_elo_after != null && m.player1_elo_before != null) {
       return m.player1_elo_after - m.player1_elo_before;
     }
-    if (m.player2_username === myUsername && m.player2_elo_after != null && m.player2_elo_before != null) {
+    if (m.player2_user_id === meId && m.player2_elo_after != null && m.player2_elo_before != null) {
       return m.player2_elo_after - m.player2_elo_before;
     }
     return null;
@@ -140,11 +142,23 @@ export default function MatchesPage() {
                         <td className="px-3 py-2"><Link to={`/matches/${m.id}`}>{formatWhen(m)}</Link></td>
                         <td className="px-3 py-2"><Link to={`/matches/${m.id}`}>{m.league_name}</Link></td>
                         <td className="px-3 py-2">
-                          <Link to={`/profile/${m.player1_username}`} className="underline hover:no-underline">{m.player1_username}</Link>
+                          {m.player1_username ? (
+                            <Link to={`/profile/${m.player1_username}`} className="underline hover:no-underline">
+                              {m.player1_display_name || m.player1_username}
+                            </Link>
+                          ) : (
+                            <span>{m.player1_display_name}</span>
+                          )}
                           {' '}
                           {t('common.vs') || 'vs'}
                           {' '}
-                          <Link to={`/profile/${m.player2_username}`} className="underline hover:no-underline">{m.player2_username}</Link>
+                          {m.player2_username ? (
+                            <Link to={`/profile/${m.player2_username}`} className="underline hover:no-underline">
+                              {m.player2_display_name || m.player2_username}
+                            </Link>
+                          ) : (
+                            <span>{m.player2_display_name}</span>
+                          )}
                         </td>
                         <td className="px-3 py-2"><Link to={`/matches/${m.id}`}>{m.player1_sets_won}-{m.player2_sets_won}</Link></td>
                         <td className="px-3 py-2">{m.is_accepted ? t('status.accepted') : t('status.pending')}</td>

--- a/frontend/src/pages/RecordMatchPage.jsx
+++ b/frontend/src/pages/RecordMatchPage.jsx
@@ -33,7 +33,7 @@ const MAX_SETS_BY_TYPE = {
 
 const schema = z.object({
   league_id: z.coerce.number().int().positive({ message: 'Select a league' }),
-  player2_id: z.coerce.number().int().positive({ message: 'Select an opponent' }),
+  player2_roster_id: z.coerce.number().int().positive({ message: 'Select an opponent' }),
   game_type: z.enum(['best_of_1', 'best_of_3', 'best_of_5', 'best_of_7']),
   player1_sets_won: z.coerce.number().int().min(0).max(4),
   player2_sets_won: z.coerce.number().int().min(0).max(4),
@@ -69,7 +69,7 @@ export default function RecordMatchPage() {
     resolver: zodResolver(schema),
     defaultValues: {
       league_id: undefined,
-      player2_id: undefined,
+      player2_roster_id: undefined,
       game_type: 'best_of_3',
       player1_sets_won: 2,
       player2_sets_won: 1,
@@ -145,7 +145,7 @@ export default function RecordMatchPage() {
   }, [setScores, form]);
 
   // Style helper: highlight close sets with orange→red gradient
-  const getSetClosenessStyle = (p1, p2) => {
+  const _getSetClosenessStyle = (p1, p2) => {
     const a = Number(p1);
     const b = Number(p2);
     if (!Number.isFinite(a) || !Number.isFinite(b)) return {};
@@ -196,7 +196,7 @@ export default function RecordMatchPage() {
         const leagueId = values.league_id;
         if (!leagueId) {
           setMembers([]);
-          form.setValue('player2_id', undefined);
+          form.setValue('player2_roster_id', undefined);
           setEloPreview(null);
           return;
         }
@@ -204,11 +204,11 @@ export default function RecordMatchPage() {
           setLoadingMembers(true);
           const { data } = await leaguesAPI.getMembers(leagueId);
           const arr = (data.members || data) || [];
-          const filtered = arr.filter((m) => m.id !== me?.id);
+          const filtered = arr.filter((m) => m.user_id !== me?.id);
           setMembers(filtered);
           // Clear opponent if not in list
-          if (filtered.findIndex((m) => m.id === values.player2_id) === -1) {
-            form.setValue('player2_id', undefined);
+          if (filtered.findIndex((m) => m.roster_id === values.player2_roster_id) === -1) {
+            form.setValue('player2_roster_id', undefined);
           }
         } catch (e) {
           console.error('Failed to load members', e);
@@ -226,15 +226,15 @@ export default function RecordMatchPage() {
     const subscription = form.watch((values) => {
       if (previewTimer.current) clearTimeout(previewTimer.current);
       previewTimer.current = setTimeout(async () => {
-        const { league_id, player2_id, player1_sets_won, player2_sets_won, player1_points_total, player2_points_total } = values;
-        if (!league_id || !player2_id || player1_sets_won == null || player2_sets_won == null) {
+        const { league_id, player2_roster_id, player1_sets_won, player2_sets_won, player1_points_total, player2_points_total } = values;
+        if (!league_id || !player2_roster_id || player1_sets_won == null || player2_sets_won == null) {
           setEloPreview(null);
           return;
         }
         try {
           const payload = {
             league_id,
-            player2_id,
+            player2_roster_id,
             player1_sets_won,
             player2_sets_won,
             player1_points_total: Number.isFinite(+player1_points_total) ? +player1_points_total : 0,
@@ -242,7 +242,7 @@ export default function RecordMatchPage() {
           };
           const { data } = await matchesAPI.previewElo(payload);
           setEloPreview(data);
-        } catch (e) {
+        } catch {
           // Ignore preview errors silently (e.g., opponent not selected or not a member)
           setEloPreview(null);
         }
@@ -256,7 +256,7 @@ export default function RecordMatchPage() {
       setSubmitting(true);
       const payload = {
         league_id: values.league_id,
-        player2_id: values.player2_id,
+        player2_roster_id: values.player2_roster_id,
         player1_sets_won: values.player1_sets_won,
         player2_sets_won: values.player2_sets_won,
         player1_points_total: values.player1_points_total,
@@ -328,7 +328,7 @@ export default function RecordMatchPage() {
 
               {/* Opponent selector */}
               <FormField
-                name="player2_id"
+                name="player2_roster_id"
                 control={form.control}
                 render={({ field }) => (
                   <FormItem>
@@ -344,8 +344,8 @@ export default function RecordMatchPage() {
                           {members.length === 0 ? (
                             <SelectItem disabled value="0">{t('recordMatch.noMembers')}</SelectItem>
                           ) : members.map((m) => (
-                            <SelectItem key={m.id} value={String(m.id)}>
-                              {m.username} {typeof m.current_elo === 'number' ? `(ELO ${m.current_elo})` : ''}
+                            <SelectItem key={m.roster_id} value={String(m.roster_id)}>
+                              {m.display_name} {typeof m.current_elo === 'number' ? `(ELO ${m.current_elo})` : ''}
                             </SelectItem>
                           ))}
                         </SelectContent>


### PR DESCRIPTION
Introduces a `league_roster` table to support placeholder members in leagues and allows matches/ELO to be recorded for them before user assignment.

The previous system required all league participants to be registered users. This change allows admins to add named placeholders to a league roster, enabling them to play matches and accumulate ELO, and later assign a real user account to that roster entry. This provides greater flexibility for league management, especially for scenarios where user accounts are created after initial league participation.

---
<a href="https://cursor.com/background-agent?bcId=bc-13952358-0ba8-411a-8176-a53b0b2b8ad2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-13952358-0ba8-411a-8176-a53b0b2b8ad2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

