### PR TITLE
Dashboard and leaderboard display issues

### DIFF
--- a/frontend/src/components/EloSparkline.jsx
+++ b/frontend/src/components/EloSparkline.jsx
@@ -17,14 +17,25 @@ const EloSparkline = ({ userId, leagueId, width = 60, height = 20, points = 20 }
         const res = await usersAPI.getEloHistory(userId, { 
           league_id: leagueId, 
           page: 1, 
-          limit: points 
+          // We'll prepend the initial `elo_before` as the first point.
+          // Request one fewer history rows so the sparkline stays roughly within `points`.
+          limit: Math.max(points - 1, 1),
         });
         
         if (cancelled) return;
         
         // Reverse to show oldest to newest (left to right)
         const historyData = (res.data.items || []).reverse();
-        setData(historyData);
+        if (historyData.length === 0) {
+          setData([]);
+          return;
+        }
+
+        // The API returns one row per match with `elo_before` + `elo_after`.
+        // Build a true time-series so that even a single match produces 2 points.
+        const first = historyData[0];
+        const series = [{ elo_after: first.elo_before }, ...historyData];
+        setData(series);
       } catch (err) {
         if (cancelled) return;
         console.error('Failed to load ELO history for sparkline:', err);
@@ -46,13 +57,13 @@ const EloSparkline = ({ userId, leagueId, width = 60, height = 20, points = 20 }
     const maxElo = Math.max(...eloValues);
     const range = maxElo - minElo || 1; // Avoid division by zero
 
-    const points = eloValues.map((elo, index) => {
+    const plotPoints = eloValues.map((elo, index) => {
       const x = (index / (eloValues.length - 1)) * width;
       const y = height - ((elo - minElo) / range) * height;
       return `${x},${y}`;
     });
 
-    return `M ${points.join(' L ')}`;
+    return `M ${plotPoints.join(' L ')}`;
   }, [data, width, height]);
 
   if (loading) {

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -266,7 +266,7 @@ const DashboardPage = () => {
                   <div className="space-y-2">
                     {leagueLeaderboards[league.id].slice(0, 5).map((player) => (
                       <div 
-                        key={player.id} 
+                        key={player.roster_id || player.user_id} 
                         className="flex items-center justify-between p-2 rounded-lg hover:bg-gray-800 transition-colors"
                       >
                         <div className="flex items-center gap-2">
@@ -287,7 +287,7 @@ const DashboardPage = () => {
                           <span className="text-sm text-gray-400">{player.current_elo}</span>
                           <div className="w-12 h-6">
                             <EloSparkline 
-                              userId={player.id} 
+                              userId={player.user_id} 
                               leagueId={league.id} 
                               width={48} 
                               height={16} 


### PR DESCRIPTION
Fixes ELO history display, sparkline trend, and placeholder member names to correctly reflect match data and user identities.

The dashboard's ELO history line incorrectly started in August due to `TimelineStats` misinterpreting single data points and the backend grouping by `recorded_at` instead of `played_at`. League sparklines remained grey because `EloSparkline` needed two points to show a trend and the dashboard passed an incorrect user ID. Placeholder member names were empty because league creation/join logic didn't default to usernames and existing data needed normalization.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5cf86b7-4129-4781-a2d2-6f1d1fa80f3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c5cf86b7-4129-4781-a2d2-6f1d1fa80f3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

