### PR TITLE
Database persistence investigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,9 @@ FRONTEND_URL=http://localhost,http://localhost:5173
 # Use Postgres when DATABASE_URL is set (e.g., on Vercel). Otherwise SQLite is used via DATABASE_PATH.
 # If sslmode is missing from DATABASE_URL, the backend appends `sslmode=require` automatically.
 # DATABASE_URL=postgresql://user:pass@host/db?sslmode=require
-DATABASE_PATH=backend/database/league.db
+# SQLite path is resolved relative to the backend working directory.
+# If you run from `backend/`, use:
+DATABASE_PATH=database/league.db
 
 # Auth
 JWT_SECRET=your-super-secret-jwt-key-change-in-production

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,8 +13,12 @@ FRONTEND_URL=http://localhost,http://localhost:5173
 # Example (Neon):
 # DATABASE_URL=postgresql://user:password@host.neon.tech:5432/db_name?sslmode=require
 
-# SQLite local database path (used when DATABASE_URL is not set)
-DATABASE_PATH=backend/database/league.db
+# SQLite local database path (used when DATABASE_URL is not set).
+# IMPORTANT: this path is resolved relative to the backend process working directory.
+# If you run `npm start` from the `backend/` folder (recommended), use:
+DATABASE_PATH=database/league.db
+# Alternatively, omit DATABASE_PATH entirely and the backend will default to `backend/database/league.db`
+# based on the location of `backend/src/models/database.js`.
 
 # Optional: override schema file paths (usually not needed)
 # DATABASE_SCHEMA_PATH=backend/database/schema.sql

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -117,7 +117,7 @@ Quick facts (current state):
 - [x] .env.example (backend)
   - Files: `backend/.env.example`
   - Action: Provide a template with local defaults and production guidance.
-    - Local: omit DATABASE_URL; set `DATABASE_PATH=backend/database/league.db`; set `FRONTEND_URL=http://localhost,http://localhost:5173`.
+    - Local: omit DATABASE_URL; set `DATABASE_PATH=database/league.db` (when running from `backend/`); set `FRONTEND_URL=http://localhost,http://localhost:5173`.
     - Production (Vercel): include `DATABASE_URL` (with sslmode=require if not present), `JWT_SECRET`, `FRONTEND_URL`.
   - Acceptance: Contributors can copy this to quickly configure local and Vercel environments.
 


### PR DESCRIPTION
Correct `DATABASE_PATH` in documentation and examples to prevent accidental creation of multiple local SQLite database files.

Previously, `DATABASE_PATH` could resolve to different file locations depending on the working directory, causing data to appear to "vanish" when switching between local run configurations. This change standardizes the path for local development.

---
<a href="https://cursor.com/background-agent?bcId=bc-19c2400e-e26d-40e7-91d6-8d8c4873de88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-19c2400e-e26d-40e7-91d6-8d8c4873de88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

