### PR TITLE
Login registration text changes

### DIFF
--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -53,10 +53,7 @@ const LoginPage = () => {
       <div className="flex-1 flex items-center justify-center px-4 py-10">
         <Card className="w-full max-w-md vg-card no-hover">
           <CardHeader className="text-center">
-            <CardTitle className="text-2xl text-blue-300">Welcome back</CardTitle>
-            <CardDescription className="text-gray-400">
-              Sign in to your Table Tennis League account
-            </CardDescription>
+            <CardTitle className="text-2xl text-blue-300">Sign In</CardTitle>
           </CardHeader>
           <CardContent>
             <form onSubmit={handleSubmit} className="space-y-4">
@@ -114,7 +111,7 @@ const LoginPage = () => {
                     Signing in...
                   </>
                 ) : (
-                  'Sign in'
+                  'Sign In'
                 )}
               </Button>
             </form>

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -108,10 +108,7 @@ const RegisterPage = () => {
       <div className="flex-1 flex items-center justify-center px-4 py-10">
         <Card className="w-full max-w-md vg-card no-hover">
           <CardHeader className="text-center">
-            <CardTitle className="text-2xl text-blue-300">Create account</CardTitle>
-            <CardDescription className="text-gray-400">
-              Join the Table Tennis League community
-            </CardDescription>
+            <CardTitle className="text-2xl text-blue-300">Register</CardTitle>
           </CardHeader>
           <CardContent>
             <form onSubmit={handleSubmit} className="space-y-4">
@@ -252,10 +249,10 @@ const RegisterPage = () => {
                 {loading ? (
                   <>
                     <LoadingSpinner size="sm" className="mr-2" />
-                    Creating account...
+                    Registering...
                   </>
                 ) : (
-                  'Create account'
+                  'Register'
                 )}
               </Button>
             </form>


### PR DESCRIPTION
Simplify login and registration page headings and button texts to just 'Sign In' and 'Register' for a cleaner UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ca02b6d-2178-4231-8a8c-c5cf58e17469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9ca02b6d-2178-4231-8a8c-c5cf58e17469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

