### PR TITLE
Add wiki link to landing page menu and improve wiki page layout

### DIFF
--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -452,6 +452,28 @@
     "submitMatch": "Spiel einreichen",
     "matchRecordedSuccess": "Spiel erfolgreich eingetragen",
     "failedToRecordMatch": "Spiel konnte nicht eingetragen werden"
+  },
+  "wiki": {
+    "chapters": "Kapitel",
+    "material": {
+      "title": "Material",
+      "text": "Bevor du neues Material kaufst, kontaktiere mich bitte unter <email>brunokreiner@hotmail.ch</email> oder die <support>Support-Seite</support> im Footer. Wir bieten deutlich günstigeres Material und Service, als bei anderen Shops insbesonders die Schweizer Shops. Wir verkaufen auch gebrauchtes Material und kaufen im Ausland mit Rabatten bzw. in grösseren Mengen ein. (Offizielle Shop-Seite folgt bald.)"
+    },
+    "trainingsplanJugend": {
+      "title": "Trainingsplan Jugend",
+      "subtitle": "Trainingsplan für Anfänger und Fortgeschrittene",
+      "monday": "Montag",
+      "tuesday": "Dienstag",
+      "thursday": "Donnerstag",
+      "baden": "Baden",
+      "wettingen": "Wettingen"
+    },
+    "demnaechst": {
+      "title": "Demnächst auf dieser Seite",
+      "item1": "Liste der Trainingserfolge",
+      "item2": "Trainingspläne",
+      "item3": "Trainingsmoral beim TTC Baden-Wettingen"
+    }
   }
 }
 

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -457,11 +457,10 @@
     "chapters": "Kapitel",
     "material": {
       "title": "Material",
-      "text": "Bevor du neues Material kaufst, kontaktiere mich bitte unter <email>brunokreiner@hotmail.ch</email> oder die <support>Support-Seite</support> im Footer. Wir bieten deutlich günstigeres Material und Service, als bei anderen Shops insbesonders die Schweizer Shops. Wir verkaufen auch gebrauchtes Material und kaufen im Ausland mit Rabatten bzw. in grösseren Mengen ein. (Offizielle Shop-Seite folgt bald.)"
+      "text": "Bevor du neues Material kaufst, kontaktiere mich bitte unter <email>brunokreiner@hotmail.ch</email> oder nutze die <support>Support-Seite</support> im Footer. Wir bieten deutlich günstigeres Material und Service, als bei anderen Shops, insbesondere den Schweizer Shops. Wir verkaufen auch gebrauchtes Material und kaufen im Ausland mit Rabatten bzw. in grösseren Mengen ein. (Offizielle Shop-Seite folgt bald.)"
     },
     "trainingsplanJugend": {
       "title": "Trainingsplan Jugend",
-      "subtitle": "Trainingsplan für Anfänger und Fortgeschrittene",
       "monday": "Montag",
       "tuesday": "Dienstag",
       "thursday": "Donnerstag",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -458,11 +458,10 @@
     "chapters": "Chapters",
     "material": {
       "title": "Equipment",
-      "text": "Before you buy new equipment, please contact me at <email>brunokreiner@hotmail.ch</email> or the <support>Support page</support> in the footer. We offer significantly cheaper equipment and service than other shops, especially Swiss shops. We also sell used equipment and buy abroad with discounts or in larger quantities. (Official shop page coming soon.)"
+      "text": "Before you buy new equipment, please contact me at <email>brunokreiner@hotmail.ch</email> or use the <support>Support page</support> in the footer. We offer significantly cheaper equipment and service than other shops, especially Swiss shops. We also sell used equipment and buy abroad with discounts or in larger quantities. (Official shop page coming soon.)"
     },
     "trainingsplanJugend": {
       "title": "Youth Training Schedule",
-      "subtitle": "Training schedule for beginners and advanced players",
       "monday": "Monday",
       "tuesday": "Tuesday",
       "thursday": "Thursday",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -453,5 +453,27 @@
     "submitMatch": "Submit Match",
     "matchRecordedSuccess": "Match recorded successfully",
     "failedToRecordMatch": "Failed to record match"
+  },
+  "wiki": {
+    "chapters": "Chapters",
+    "material": {
+      "title": "Equipment",
+      "text": "Before you buy new equipment, please contact me at <email>brunokreiner@hotmail.ch</email> or the <support>Support page</support> in the footer. We offer significantly cheaper equipment and service than other shops, especially Swiss shops. We also sell used equipment and buy abroad with discounts or in larger quantities. (Official shop page coming soon.)"
+    },
+    "trainingsplanJugend": {
+      "title": "Youth Training Schedule",
+      "subtitle": "Training schedule for beginners and advanced players",
+      "monday": "Monday",
+      "tuesday": "Tuesday",
+      "thursday": "Thursday",
+      "baden": "Baden",
+      "wettingen": "Wettingen"
+    },
+    "demnaechst": {
+      "title": "Coming soon on this page",
+      "item1": "List of training achievements",
+      "item2": "Training plans",
+      "item3": "Training morale at TTC Baden-Wettingen"
+    }
   }
 }

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Trophy, Users, ChevronRight, ListChecks, Calendar, Globe, Sparkles } from 'lucide-react';
+import { Trophy, Users, ChevronRight, ListChecks, Calendar, Globe, Sparkles, BookOpen } from 'lucide-react';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 import { leaguesAPI } from '../services/api';
 import MedalIcon from '@/components/MedalIcon';
@@ -135,6 +135,17 @@ const LandingPage = () => {
               </span>
             </Link>
             <div className="flex items-center gap-3">
+              <Button variant="ghost" size="sm" asChild className="text-gray-400 hover:text-white">
+                <Link to="/wiki/ttc-baden-wettingen" className="flex items-center gap-2">
+                  <BookOpen className="h-4 w-4" />
+                  <span className="hidden sm:inline">
+                    <span className="inline-flex items-start gap-1">
+                      <span>TTC Baden-Wettingen</span>
+                      <sup className="text-[10px] font-semibold text-blue-400 inline-block -skew-y-3">wiki</sup>
+                    </span>
+                  </span>
+                </Link>
+              </Button>
               <Button variant="ghost" size="sm" asChild className="text-gray-400 hover:text-white">
                 <Link to="/login">Log in</Link>
               </Button>

--- a/frontend/src/pages/TtcBadenWettingenWikiPage.jsx
+++ b/frontend/src/pages/TtcBadenWettingenWikiPage.jsx
@@ -1,9 +1,9 @@
 import { Link } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
+import { useTranslation, Trans } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 
 const TtcBadenWettingenWikiPage = () => {
-  const { i18n } = useTranslation();
+  const { i18n, t } = useTranslation();
 
   return (
     <div className="mx-auto max-w-6xl">
@@ -37,36 +37,35 @@ const TtcBadenWettingenWikiPage = () => {
           </header>
 
           <section id="material" className="space-y-3 scroll-mt-24">
-            <h2 className="cyberpunk-subtitle text-xl">Material</h2>
+            <h2 className="cyberpunk-subtitle text-xl">{t('wiki.material.title')}</h2>
             <p className="text-sm text-gray-300 leading-relaxed">
-              Bevor du neues Material kaufst, kontaktiere bitte{' '}
-              <a
-                href="mailto:brunokreiner@hotmail.ch"
-                className="text-blue-400 hover:text-blue-300 underline"
-              >
-                brunokreiner@hotmail.ch
-              </a>{' '}
-              oder die{' '}
-              <Link to="/support" className="text-blue-400 hover:text-blue-300 underline">
-                Support-Seite
-              </Link>{' '}
-              im Footer. Wir koennen alles rund um Material uebernehmen und deutlich guenstiger
-              verkaufen als offizielle Shops, zum Beispiel nationale Stores. Wir verkaufen auch
-              gebrauchtes Material und kaufen im Ausland mit Rabatten bzw. in groesseren Mengen ein.
-              (Offizielle Shop-Seite folgt bald.)
+              <Trans
+                i18nKey="wiki.material.text"
+                components={{
+                  email: (
+                    <a
+                      href="mailto:brunokreiner@hotmail.ch"
+                      className="text-blue-400 hover:text-blue-300 underline"
+                    />
+                  ),
+                  support: (
+                    <Link to="/support" className="text-blue-400 hover:text-blue-300 underline" />
+                  )
+                }}
+              />
             </p>
           </section>
 
           <section id="trainingsplan-jugend" className="space-y-4 scroll-mt-24">
-            <h2 className="cyberpunk-subtitle text-xl">Trainingsplan Jugend</h2>
-            <p className="text-sm text-gray-400">Trainingsplan fuer Anfaenger und Fortgeschrittene</p>
+            <h2 className="cyberpunk-subtitle text-xl">{t('wiki.trainingsplanJugend.title')}</h2>
+            <p className="text-sm text-gray-400">{t('wiki.trainingsplanJugend.subtitle')}</p>
 
             <div className="space-y-3">
               <div className="space-y-1">
-                <h3 className="text-base font-semibold text-gray-200">Montag</h3>
+                <h3 className="text-base font-semibold text-gray-200">{t('wiki.trainingsplanJugend.monday')}</h3>
                 <p className="text-sm text-gray-300">18:00 - 20:30</p>
                 <p className="text-sm text-gray-300">
-                  Baden -&gt;{' '}
+                  {t('wiki.trainingsplanJugend.baden')} -&gt;{' '}
                   <a
                     href="https://share.google/DJjlIIBNnQcPDDbqa"
                     className="text-blue-400 hover:text-blue-300 underline"
@@ -79,10 +78,10 @@ const TtcBadenWettingenWikiPage = () => {
               </div>
 
               <div className="space-y-1">
-                <h3 className="text-base font-semibold text-gray-200">Dienstag</h3>
+                <h3 className="text-base font-semibold text-gray-200">{t('wiki.trainingsplanJugend.tuesday')}</h3>
                 <p className="text-sm text-gray-300">17:30 - 19:30</p>
                 <p className="text-sm text-gray-300">
-                  Wettingen -&gt;{' '}
+                  {t('wiki.trainingsplanJugend.wettingen')} -&gt;{' '}
                   <a
                     href="https://maps.app.goo.gl/j2an2j8ggnKDAjFP9"
                     className="text-blue-400 hover:text-blue-300 underline"
@@ -95,10 +94,10 @@ const TtcBadenWettingenWikiPage = () => {
               </div>
 
               <div className="space-y-1">
-                <h3 className="text-base font-semibold text-gray-200">Donnerstag</h3>
+                <h3 className="text-base font-semibold text-gray-200">{t('wiki.trainingsplanJugend.thursday')}</h3>
                 <p className="text-sm text-gray-300">17:30 - 19:30</p>
                 <p className="text-sm text-gray-300">
-                  Wettingen -&gt;{' '}
+                  {t('wiki.trainingsplanJugend.wettingen')} -&gt;{' '}
                   <a
                     href="https://maps.app.goo.gl/j2an2j8ggnKDAjFP9"
                     className="text-blue-400 hover:text-blue-300 underline"
@@ -113,28 +112,28 @@ const TtcBadenWettingenWikiPage = () => {
           </section>
 
           <section id="demnaechst" className="space-y-3 scroll-mt-24">
-            <h2 className="cyberpunk-subtitle text-xl">Demnächst auf dieser Seite</h2>
+            <h2 className="cyberpunk-subtitle text-xl">{t('wiki.demnaechst.title')}</h2>
             <ul className="list-disc space-y-1 pl-5 text-sm text-gray-300">
-              <li>Liste der Trainingserfolge</li>
-              <li>Trainingsplaene</li>
-              <li>Trainingsmoral beim TTC Baden-Wettingen</li>
+              <li>{t('wiki.demnaechst.item1')}</li>
+              <li>{t('wiki.demnaechst.item2')}</li>
+              <li>{t('wiki.demnaechst.item3')}</li>
             </ul>
           </section>
         </div>
 
         <aside className="lg:sticky lg:top-24 h-fit">
           <div className="rounded-lg border border-gray-800 bg-gray-900/40 p-4 space-y-3">
-            <div className="text-sm font-semibold text-gray-200">Kapitel</div>
+            <div className="text-sm font-semibold text-gray-200">{t('wiki.chapters')}</div>
             <nav className="text-sm text-gray-400">
               <ul className="space-y-2">
                 <li>
-                  <a href="#material" className="hover:text-blue-300">Material</a>
+                  <a href="#material" className="hover:text-blue-300">{t('wiki.material.title')}</a>
                 </li>
                 <li>
-                  <a href="#trainingsplan-jugend" className="hover:text-blue-300">Trainingsplan Jugend</a>
+                  <a href="#trainingsplan-jugend" className="hover:text-blue-300">{t('wiki.trainingsplanJugend.title')}</a>
                 </li>
                 <li>
-                  <a href="#demnaechst" className="hover:text-blue-300">Demnächst</a>
+                  <a href="#demnaechst" className="hover:text-blue-300">{t('wiki.demnaechst.title')}</a>
                 </li>
               </ul>
             </nav>

--- a/frontend/src/pages/TtcBadenWettingenWikiPage.jsx
+++ b/frontend/src/pages/TtcBadenWettingenWikiPage.jsx
@@ -9,7 +9,7 @@ const TtcBadenWettingenWikiPage = () => {
     <div className="mx-auto max-w-6xl">
       <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_240px]">
         <div className="space-y-8">
-          <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between mt-8">
             <h1 className="cyberpunk-title text-3xl text-blue-300">
               <span className="inline-flex items-start gap-2">
                 <span>TTC Baden-Wettingen</span>

--- a/frontend/src/pages/TtcBadenWettingenWikiPage.jsx
+++ b/frontend/src/pages/TtcBadenWettingenWikiPage.jsx
@@ -58,7 +58,6 @@ const TtcBadenWettingenWikiPage = () => {
 
           <section id="trainingsplan-jugend" className="space-y-4 scroll-mt-24">
             <h2 className="cyberpunk-subtitle text-xl">{t('wiki.trainingsplanJugend.title')}</h2>
-            <p className="text-sm text-gray-400">{t('wiki.trainingsplanJugend.subtitle')}</p>
 
             <div className="space-y-3">
               <div className="space-y-1">


### PR DESCRIPTION
- Add wiki link to landing page header menu when logged out
- Ensure wiki page has right-hand side menu for each chapter
- Add margin-top to wiki page title for proper spacing
- Footer remains present via Layout component