### PR TITLE
Further optimize dashboard/league loading performance

### DIFF
--- a/backend/database/schema.pg.sql
+++ b/backend/database/schema.pg.sql
@@ -273,5 +273,14 @@ CREATE INDEX IF NOT EXISTS idx_elo_history_match_id ON elo_history(match_id);
 CREATE INDEX IF NOT EXISTS idx_elo_history_user_league_recorded ON elo_history(user_id, league_id, recorded_at);
 -- Note: idx_elo_history_roster_id is created in ensureRosterIndexes() after roster_id column is ensured
 
+-- Roster composite index for membership lookups (used by GET /api/leagues EXISTS subqueries)
+CREATE INDEX IF NOT EXISTS idx_league_roster_league_user ON league_roster(league_id, user_id);
+
+-- Matches composite for accepted match counts with played_at (covers subqueries + MAX(played_at))
+CREATE INDEX IF NOT EXISTS idx_matches_league_accepted_played ON matches(league_id, is_accepted, played_at);
+
+-- Roster roster_id index for ELO history lookups
+CREATE INDEX IF NOT EXISTS idx_elo_history_roster_league ON elo_history(roster_id, league_id);
+
 -- Match sets table
 CREATE INDEX IF NOT EXISTS idx_match_sets_match_id ON match_sets(match_id);

--- a/backend/src/models/database.js
+++ b/backend/src/models/database.js
@@ -28,7 +28,13 @@ class Database {
             const hasQuery = rawUrl.includes('?');
             const hasSslMode = /[?&]sslmode=/i.test(rawUrl);
             const connString = hasSslMode ? rawUrl : `${rawUrl}${hasQuery ? '&' : '?'}sslmode=require`;
-            this.pool = new Pool({ connectionString: connString, ssl: { rejectUnauthorized: false } });
+            this.pool = new Pool({
+                connectionString: connString,
+                ssl: { rejectUnauthorized: false },
+                max: 10,
+                idleTimeoutMillis: 30000,
+                connectionTimeoutMillis: 5000,
+            });
             try {
                 await this.pool.query('SELECT 1');
                 console.log('Connected to Postgres database');

--- a/frontend/src/components/ui/LoadingSpinner.jsx
+++ b/frontend/src/components/ui/LoadingSpinner.jsx
@@ -7,8 +7,13 @@ const LoadingSpinner = ({ size = 'default', className = '' }) => {
     lg: 'h-12 w-12',
   };
 
+  // Use min-h-[200px] by default to vertically center in page-level contexts.
+  // Callers can override via className (e.g. small inline spinners pass their own height).
+  const hasHeight = /\b(min-h-|h-)\[/.test(className) || /\bmin-h-/.test(className);
+  const heightClass = hasHeight ? '' : (size === 'sm' ? '' : 'min-h-[200px]');
+
   return (
-    <div className={`flex items-center justify-center ${className}`}>
+    <div className={`flex items-center justify-center ${heightClass} ${className}`}>
       <Loader2 className={`animate-spin text-blue-400 ${sizeClasses[size]}`} />
     </div>
   );


### PR DESCRIPTION
Backend:
- Replace expensive LEFT JOIN + COUNT(DISTINCT) with subqueries in GET /api/leagues, GET /api/leagues/:id, and snapshot builder. The old approach joined every roster entry × every match per league, creating huge intermediate result sets. Subqueries use indexes directly.
- Add composite indexes: league_roster(league_id, user_id), matches(league_id, is_accepted, played_at), elo_history(roster_id, league_id)
- Configure Neon Pool: max=10, idleTimeout=30s, connectionTimeout=5s
- Remove CORS console.log on every request (only log rejections)
- Switch morgan from 'combined' to 'short' (less stdout overhead)
- Make dbReady middleware one-shot (null after first resolve)
- Cap leagues limit to 500 to prevent unbounded queries

Frontend:
- Remove redundant authAPI.getMe() from DashboardPage (AuthContext already calls it on init - saved one full round-trip)
- Fix leaderboardSectionRef placed on TimelineStats div instead of leaderboard section (IntersectionObserver was firing immediately, bypassing lazy loading entirely)
- Fix LoadingSpinner centering: add min-h-[200px] for non-sm spinners so page-level loaders are vertically centered

https://claude.ai/code/session_019Mvh1zMSASrP1aSbzMWn5o