### PR TITLE
fix(mobile): unblock logout in menu and align dashboard stat numbers

### DIFF
--- a/frontend/src/components/layout/MobileMenu.jsx
+++ b/frontend/src/components/layout/MobileMenu.jsx
@@ -90,6 +90,9 @@ const MobileMenu = ({
           background: 'var(--bg-2)',
           borderLeft: '1px solid var(--line-soft)',
           boxShadow: '-20px 0 60px -10px oklch(0.10 0 0 / 0.5)',
+          paddingBottom: isAuthenticated
+            ? 'calc(80px + env(safe-area-inset-bottom, 0px))'
+            : undefined,
         }}
         role="dialog"
         aria-modal="true"

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -307,12 +307,12 @@ const DashboardPage = () => {
           ].map((row, i) => (
             <div
               key={i}
-              className="px-5 py-3.5 flex justify-between items-baseline border-b last:border-b-0"
+              className="px-5 py-3.5 grid grid-cols-[1fr_auto_minmax(5.5rem,auto)] gap-x-3 items-baseline border-b last:border-b-0"
               style={{ borderColor: 'var(--line-soft)' }}
             >
               <span className="font-mono text-[11px] text-[var(--fg-3)] tracking-[0.08em] uppercase">{row.k}</span>
               <span
-                className="font-bold tabular-nums"
+                className="font-bold tabular-nums text-right"
                 style={{
                   fontFamily: '"Inter Tight", sans-serif',
                   fontSize: 24,
@@ -320,8 +320,8 @@ const DashboardPage = () => {
                 }}
               >
                 {row.v}
-                <small className="ml-1 font-normal font-mono text-[11px] text-[var(--fg-3)]">{row.suf}</small>
               </span>
+              <small className="font-normal font-mono text-[11px] text-[var(--fg-3)] text-left">{row.suf}</small>
             </div>
           ))}
         </div>


### PR DESCRIPTION
The mobile menu drawer is rendered at z-50 while the bottom tabbar sits
at z-80, so the drawer's footer (with the logout button) was hidden
underneath the tabbar with no way to reach it. Reserve tabbar room with
bottom padding when authenticated.

The dashboard summary rows used flex+justify-between, so the value
numbers floated based on suffix length and never lined up. Switch to a
3-column grid (label / number / suffix) with the number column right-
aligned so digits align cleanly across rows.

https://claude.ai/code/session_01DZkF8SYm8mbpcsRX6sRKF5