### PR TITLE
Simplify EloSparkline trend calculation to use full data range

### DIFF
--- a/frontend/src/components/EloSparkline.jsx
+++ b/frontend/src/components/EloSparkline.jsx
@@ -118,25 +118,9 @@ const EloSparkline = ({ userId, rosterId, leagueId, width = 60, height = 20, poi
     );
   }
 
+  const startingElo = data[0].elo_after;
   const latestElo = data[data.length - 1].elo_after;
-  const oneMonthAgo = new Date();
-  oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
-  const targetTime = oneMonthAgo.getTime();
-  let closestPoint = data[0];
-  let closestDiff = Math.abs(new Date(closestPoint.recorded_at).getTime() - targetTime);
-
-  for (let i = 1; i < data.length; i += 1) {
-    const point = data[i];
-    const pointTime = new Date(point.recorded_at).getTime();
-    const diff = Math.abs(pointTime - targetTime);
-    if (diff < closestDiff) {
-      closestPoint = point;
-      closestDiff = diff;
-    }
-  }
-
-  const comparisonElo = closestPoint.elo_after;
-  const trend = latestElo > comparisonElo ? 'up' : latestElo < comparisonElo ? 'down' : 'flat';
+  const trend = latestElo > startingElo ? 'up' : latestElo < startingElo ? 'down' : 'flat';
 
   return (
     <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary
Simplified the trend calculation logic in the EloSparkline component by comparing the latest Elo rating against the starting Elo rating instead of finding the closest data point from one month ago.

## Key Changes
- Removed the one-month lookback logic that searched for the closest historical data point to a specific date
- Changed trend comparison to use `startingElo` (first data point) instead of `comparisonElo` (closest point to one month ago)
- Eliminated ~15 lines of date calculation and loop logic

## Implementation Details
The trend is now determined by comparing the latest Elo rating against the earliest Elo rating in the dataset, providing a simpler view of overall direction change across the entire data range rather than a fixed one-month window.

https://claude.ai/code/session_013JRpSFs8b6GMKN5hWHw9tJ