### PR TITLE
Remove text label from quick match FAB button

### DIFF
--- a/frontend/src/components/layout/Layout.jsx
+++ b/frontend/src/components/layout/Layout.jsx
@@ -448,7 +448,7 @@ const Layout = () => {
             <Trophy className="ic" /> <span>{t('nav.leagues')}</span>
           </Link>
           <Link to="/app/quick-match" className="fab" aria-label={t('cta.recordMatch')}>
-            <Plus className="ic" /> <span>{t('cta.recordMatch')}</span>
+            <Plus className="ic" strokeWidth={3} />
           </Link>
           <Link to="/app/matches" className={isActive('/app/matches') ? 'active' : ''}>
             <Swords className="ic" /> <span>{t('nav.matches')}</span>


### PR DESCRIPTION
## Summary
Updated the quick match floating action button (FAB) to display only an icon without the accompanying text label, while improving the icon's visual prominence.

## Changes
- Removed the `<span>{t('cta.recordMatch')}</span>` text label from the quick match FAB button
- Added `strokeWidth={3}` to the Plus icon to increase its visual weight and make it more prominent as a standalone icon

## Details
The quick match button now relies solely on the Plus icon for visual communication, with the aria-label still providing accessibility context for screen readers. The increased stroke width compensates for the removal of the text label by making the icon more visually prominent and easier to identify at a glance.

https://claude.ai/code/session_01KNbfAyZ48qQ9smGzWh1yUc