### PR TITLE
feat(ui): use 3D spinning ball as loader on every page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,9 +9,96 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600&family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&display=swap" rel="stylesheet">
+    <style>
+      /* First-paint splash — visible before React mounts. Replaced as soon
+         as ReactDOM renders the app into #root. Same ball-with-orbital-ink
+         language as the in-app loader. */
+      html, body { background: #0d0d0e; margin: 0; }
+      #tt-boot-splash {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #0d0d0e;
+        z-index: 9999;
+      }
+      #tt-boot-splash .tt-boot-wrap {
+        position: relative;
+        width: 84px;
+        height: 84px;
+      }
+      #tt-boot-splash .tt-boot-ball {
+        position: relative;
+        z-index: 1;
+        width: 100%;
+        height: 100%;
+        border-radius: 50%;
+        background: radial-gradient(circle at 32% 30%, #ffffff 0%, #f4ebd9 65%, #c8b88a 100%);
+        box-shadow: 0 4px 12px rgba(0,0,0,0.45), inset -3px -4px 8px rgba(0,0,0,0.12);
+        display: grid;
+        place-items: center;
+      }
+      #tt-boot-splash .tt-boot-ball svg {
+        width: 56%;
+        height: 56%;
+        color: #1a1208;
+      }
+      #tt-boot-splash .tt-boot-ink {
+        position: absolute;
+        inset: -50%;
+        width: 200%;
+        height: 200%;
+        z-index: 2;
+        pointer-events: none;
+        overflow: visible;
+      }
+      #tt-boot-splash .tt-boot-ink-spin {
+        transform-origin: 0 0;
+        animation: tt-boot-rotate 1.2s linear infinite;
+      }
+      #tt-boot-splash .tt-boot-ink-spin path {
+        fill: none;
+        stroke: #18120b;
+        stroke-width: 3;
+        stroke-linecap: round;
+      }
+      #tt-boot-splash .tt-boot-ink-spin circle {
+        fill: #18120b;
+      }
+      @keyframes tt-boot-rotate {
+        from { transform: rotate(0deg); }
+        to   { transform: rotate(360deg); }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        #tt-boot-splash .tt-boot-ink-spin { animation-duration: 4s; }
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div id="tt-boot-splash" aria-label="Loading" role="status">
+        <span class="tt-boot-wrap">
+          <span class="tt-boot-ball">
+            <svg viewBox="0 0 26 26" fill="none" aria-hidden="true">
+              <circle cx="9" cy="13" r="6.5" fill="currentColor" />
+              <circle cx="18" cy="13" r="4" fill="#ff5a1f" />
+            </svg>
+          </span>
+          <svg class="tt-boot-ink" viewBox="-100 -100 200 200" aria-hidden="true">
+            <g class="tt-boot-ink-spin">
+              <path d="M 28 -64 A 70 70 0 0 1 60 -36" />
+              <path d="M -62 26 A 67 67 0 0 1 -38 60" stroke-opacity="0.78" />
+              <path d="M -72 -22 A 75 75 0 0 1 -50 -56" stroke-opacity="0.6" stroke-width="2.2" />
+              <path d="M 64 32 A 71 71 0 0 1 38 64" stroke-opacity="0.55" stroke-width="2.4" />
+              <circle cx="-18" cy="-78" r="3" fill-opacity="0.78" />
+              <circle cx="80" cy="-6" r="2" fill-opacity="0.6" />
+              <circle cx="14" cy="84" r="2.4" fill-opacity="0.55" />
+            </g>
+          </svg>
+        </span>
+      </div>
+    </div>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/frontend/src/components/BallLoader.jsx
+++ b/frontend/src/components/BallLoader.jsx
@@ -1,0 +1,166 @@
+import { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import { getBallTexture } from './ballTexture';
+
+// Lightweight, non-interactive loading variant of the hero SpinningBall:
+// the same branded ping-pong ball, auto-rotating with orbital ink streaks
+// circling around it. No drag, no meter, no shatter, no HUD.
+export default function BallLoader({ size = 64, className = '' }) {
+  const wrapRef = useRef(null);
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const wrap = wrapRef.current;
+    const canvas = canvasRef.current;
+    if (!wrap || !canvas) return undefined;
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(35, 1, 0.1, 100);
+    camera.position.set(0, 0, 4.2);
+
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+    const tex = getBallTexture();
+    tex.anisotropy = renderer.capabilities.getMaxAnisotropy?.() || 8;
+    const geo = new THREE.SphereGeometry(1, 64, 48);
+    const mat = new THREE.MeshStandardMaterial({ map: tex, roughness: 0.55, metalness: 0.05 });
+    const ball = new THREE.Mesh(geo, mat);
+    scene.add(ball);
+
+    const ambient = new THREE.AmbientLight(0xffffff, 0.55);
+    scene.add(ambient);
+    const key = new THREE.DirectionalLight(0xffffff, 1.4);
+    key.position.set(-2.5, 3, 4);
+    scene.add(key);
+    const rim = new THREE.DirectionalLight(0xff8a55, 0.6);
+    rim.position.set(3, -1, -2);
+    scene.add(rim);
+    const fill = new THREE.DirectionalLight(0xffffff, 0.35);
+    fill.position.set(2, -2, 3);
+    scene.add(fill);
+
+    const resize = () => {
+      const r = wrap.getBoundingClientRect();
+      const w = Math.max(1, r.width);
+      const h = Math.max(1, r.height);
+      renderer.setSize(w, h, false);
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+    };
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(wrap);
+
+    const reduceMotion =
+      typeof window !== 'undefined' &&
+      window.matchMedia &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const spinSpeed = reduceMotion ? 0.6 : 2.4; // rad/s
+
+    let raf = 0;
+    let last = performance.now();
+    let visible = true;
+
+    const onVis = () => {
+      visible = document.visibilityState !== 'hidden';
+      if (visible) {
+        last = performance.now();
+        if (!raf) raf = requestAnimationFrame(tick);
+      } else if (raf) {
+        cancelAnimationFrame(raf);
+        raf = 0;
+      }
+    };
+    document.addEventListener('visibilitychange', onVis);
+
+    function tick(now) {
+      const dt = Math.min(0.05, (now - last) / 1000);
+      last = now;
+      ball.rotation.y += spinSpeed * dt;
+      ball.rotation.x = Math.sin(now * 0.0008) * 0.18;
+      renderer.render(scene, camera);
+      raf = requestAnimationFrame(tick);
+    }
+    raf = requestAnimationFrame(tick);
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVis);
+      if (raf) cancelAnimationFrame(raf);
+      ro.disconnect();
+      geo.dispose();
+      mat.dispose();
+      // Do NOT dispose the cached texture — other instances may still use it.
+      renderer.dispose();
+    };
+  }, []);
+
+  const sz = `${size}px`;
+  return (
+    <div
+      ref={wrapRef}
+      className={`ball-loader ${className}`}
+      style={{
+        position: 'relative',
+        width: sz,
+        height: sz,
+        flexShrink: 0,
+      }}
+      role="status"
+      aria-label="Loading"
+    >
+      {/* Soft drop shadow under the ball */}
+      <span
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          left: '50%',
+          bottom: '-8%',
+          width: '70%',
+          height: '12%',
+          transform: 'translateX(-50%)',
+          background:
+            'radial-gradient(50% 50% at 50% 50%, rgba(0,0,0,0.45), rgba(0,0,0,0) 70%)',
+          filter: 'blur(6px)',
+          pointerEvents: 'none',
+          zIndex: 1,
+        }}
+      />
+      {/* Orbital ink streaks — same impact-frame language as the hero ball.
+          Wrapper rotates via the existing tt-loading-ink-rotate keyframe. */}
+      <svg
+        aria-hidden="true"
+        viewBox="-100 -100 200 200"
+        style={{
+          position: 'absolute',
+          inset: '-15%',
+          width: '130%',
+          height: '130%',
+          pointerEvents: 'none',
+          zIndex: 2,
+          overflow: 'visible',
+        }}
+      >
+        <g className="tt-loading-ink-spin">
+          <path d="M 28 -64 A 70 70 0 0 1 60 -36" />
+          <path d="M -62 26 A 67 67 0 0 1 -38 60" strokeOpacity="0.78" />
+          <path d="M -72 -22 A 75 75 0 0 1 -50 -56" strokeOpacity="0.6" strokeWidth="2.2" />
+          <path d="M 64 32 A 71 71 0 0 1 38 64" strokeOpacity="0.55" strokeWidth="2.4" />
+          <circle cx="-18" cy="-78" r="3" fillOpacity="0.78" />
+          <circle cx="80" cy="-6" r="2" fillOpacity="0.6" />
+          <circle cx="14" cy="84" r="2.4" fillOpacity="0.55" />
+        </g>
+      </svg>
+      <canvas
+        ref={canvasRef}
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          display: 'block',
+          zIndex: 3,
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/SpinningBall.jsx
+++ b/frontend/src/components/SpinningBall.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import * as THREE from 'three';
+import { getBallTexture } from './ballTexture';
 
 /**
  * Interactive ping-pong ball — Three.js sphere with the leagues.lol mark
@@ -32,91 +33,6 @@ export default function SpinningBall() {
     const inkSvg = inkSvgRef.current;
     if (!wrap || !canvas || !inkSvg) return undefined;
 
-    // ===== Build the branded ball texture =====
-    const buildTexture = () => {
-      const W = 2048;
-      const H = 1024;
-      const c = document.createElement('canvas');
-      c.width = W;
-      c.height = H;
-      const ctx = c.getContext('2d');
-
-      // Brighter off-white base — pure white at top, warm cream at bottom
-      const grd = ctx.createLinearGradient(0, 0, 0, H);
-      grd.addColorStop(0, '#ffffff');
-      grd.addColorStop(1, '#f4ebd9');
-      ctx.fillStyle = grd;
-      ctx.fillRect(0, 0, W, H);
-
-      // Faint equator seam — slightly softened to preserve brightness
-      ctx.globalAlpha = 0.06;
-      ctx.fillStyle = '#000';
-      ctx.fillRect(0, H * 0.5 - 1, W, 2);
-      ctx.globalAlpha = 1;
-
-      // Lockup: paired-dot icon + leagues.lol wordmark — placed once at U=0.5
-      const drawLockup = (cx, cy, scale) => {
-        ctx.save();
-        ctx.translate(cx, cy);
-        ctx.scale(scale, scale);
-        const iconSize = 130;
-        const iconX = -340;
-        const iconY = 0;
-
-        // Orange ball behind, white ball in front (matches the brand mark)
-        ctx.fillStyle = '#ff5a1f';
-        ctx.strokeStyle = '#000';
-        ctx.lineWidth = 4;
-        ctx.beginPath();
-        ctx.arc(iconX + 48, iconY, iconSize * 0.32, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.stroke();
-        ctx.fillStyle = '#fbf7ee';
-        ctx.beginPath();
-        ctx.arc(iconX - 18, iconY, iconSize / 2, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.stroke();
-
-        // Wordmark
-        ctx.font = '900 180px Inter, system-ui, sans-serif';
-        ctx.textBaseline = 'middle';
-        ctx.textAlign = 'left';
-        ctx.lineWidth = 5;
-        ctx.lineJoin = 'round';
-        const tx = iconX + 120;
-        const ty = iconY;
-        ctx.fillStyle = '#fbf7ee';
-        ctx.strokeStyle = '#000';
-        const t1 = 'leagues';
-        ctx.strokeText(t1, tx, ty);
-        ctx.fillText(t1, tx, ty);
-        const w1 = ctx.measureText(t1).width;
-        ctx.fillStyle = '#ff5a1f';
-        const t2 = '.lol';
-        ctx.strokeText(t2, tx + w1, ty);
-        ctx.fillText(t2, tx + w1, ty);
-        ctx.restore();
-      };
-      drawLockup(W * 0.5, H * 0.5, 0.85);
-
-      // Subtle dimple noise
-      ctx.globalAlpha = 0.06;
-      ctx.fillStyle = '#3a2d18';
-      for (let i = 0; i < 2200; i += 1) {
-        const x = Math.random() * W;
-        const y = Math.random() * H;
-        const r = Math.random() * 1.6 + 0.3;
-        ctx.beginPath();
-        ctx.arc(x, y, r, 0, Math.PI * 2);
-        ctx.fill();
-      }
-      ctx.globalAlpha = 1;
-
-      const t = new THREE.CanvasTexture(c);
-      t.colorSpace = THREE.SRGBColorSpace;
-      return t;
-    };
-
     // ===== Three.js scene =====
     const scene = new THREE.Scene();
     const camera = new THREE.PerspectiveCamera(35, 1, 0.1, 100);
@@ -125,7 +41,7 @@ export default function SpinningBall() {
     const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
 
-    const tex = buildTexture();
+    const tex = getBallTexture();
     tex.anisotropy = renderer.capabilities.getMaxAnisotropy?.() || 8;
     const geo = new THREE.SphereGeometry(1, 128, 96);
     const mat = new THREE.MeshStandardMaterial({ map: tex, roughness: 0.55, metalness: 0.05 });
@@ -961,7 +877,8 @@ export default function SpinningBall() {
         m.geometry?.dispose();
         m.material?.dispose();
       }
-      tex.dispose();
+      // Texture is module-cached and shared with BallLoader instances —
+      // do not dispose it here.
       geo.dispose();
       mat.dispose();
       renderer.dispose();

--- a/frontend/src/components/ballTexture.js
+++ b/frontend/src/components/ballTexture.js
@@ -1,0 +1,90 @@
+import * as THREE from 'three';
+
+// Cached at module scope so every BallLoader / SpinningBall instance reuses
+// the same heavy 2048x1024 canvas + texture (~5–10ms one-time build cost).
+let cachedTexture = null;
+
+export function getBallTexture() {
+  if (cachedTexture) return cachedTexture;
+
+  const W = 2048;
+  const H = 1024;
+  const c = document.createElement('canvas');
+  c.width = W;
+  c.height = H;
+  const ctx = c.getContext('2d');
+
+  // Off-white base — pure white at top, warm cream at bottom
+  const grd = ctx.createLinearGradient(0, 0, 0, H);
+  grd.addColorStop(0, '#ffffff');
+  grd.addColorStop(1, '#f4ebd9');
+  ctx.fillStyle = grd;
+  ctx.fillRect(0, 0, W, H);
+
+  // Faint equator seam
+  ctx.globalAlpha = 0.06;
+  ctx.fillStyle = '#000';
+  ctx.fillRect(0, H * 0.5 - 1, W, 2);
+  ctx.globalAlpha = 1;
+
+  // Lockup: paired-dot icon + leagues.lol wordmark
+  const drawLockup = (cx, cy, scale) => {
+    ctx.save();
+    ctx.translate(cx, cy);
+    ctx.scale(scale, scale);
+    const iconSize = 130;
+    const iconX = -340;
+    const iconY = 0;
+
+    ctx.fillStyle = '#ff5a1f';
+    ctx.strokeStyle = '#000';
+    ctx.lineWidth = 4;
+    ctx.beginPath();
+    ctx.arc(iconX + 48, iconY, iconSize * 0.32, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+    ctx.fillStyle = '#fbf7ee';
+    ctx.beginPath();
+    ctx.arc(iconX - 18, iconY, iconSize / 2, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+
+    ctx.font = '900 180px Inter, system-ui, sans-serif';
+    ctx.textBaseline = 'middle';
+    ctx.textAlign = 'left';
+    ctx.lineWidth = 5;
+    ctx.lineJoin = 'round';
+    const tx = iconX + 120;
+    const ty = iconY;
+    ctx.fillStyle = '#fbf7ee';
+    ctx.strokeStyle = '#000';
+    const t1 = 'leagues';
+    ctx.strokeText(t1, tx, ty);
+    ctx.fillText(t1, tx, ty);
+    const w1 = ctx.measureText(t1).width;
+    ctx.fillStyle = '#ff5a1f';
+    const t2 = '.lol';
+    ctx.strokeText(t2, tx + w1, ty);
+    ctx.fillText(t2, tx + w1, ty);
+    ctx.restore();
+  };
+  drawLockup(W * 0.5, H * 0.5, 0.85);
+
+  // Subtle dimple noise
+  ctx.globalAlpha = 0.06;
+  ctx.fillStyle = '#3a2d18';
+  for (let i = 0; i < 2200; i += 1) {
+    const x = Math.random() * W;
+    const y = Math.random() * H;
+    const r = Math.random() * 1.6 + 0.3;
+    ctx.beginPath();
+    ctx.arc(x, y, r, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.globalAlpha = 1;
+
+  const t = new THREE.CanvasTexture(c);
+  t.colorSpace = THREE.SRGBColorSpace;
+  cachedTexture = t;
+  return t;
+}

--- a/frontend/src/components/ui/LoadingSpinner.jsx
+++ b/frontend/src/components/ui/LoadingSpinner.jsx
@@ -1,9 +1,14 @@
+import { lazy, Suspense } from 'react';
 import { BrandMark } from '@/components/layout/Brand';
 
-// Branded loading indicator — a still ping-pong ball with the leagues.lol
-// brand mark on its surface, surrounded by orbital ink streaks (arcs +
-// dots) that rotate around it. Same impact-frame language the hero
-// SpinningBall throws off when it spins. Pure CSS / SVG — no WebGL.
+// Heavy 3D loader is code-split so it only ships when actually rendered.
+const BallLoader = lazy(() => import('@/components/BallLoader'));
+
+// Branded loading indicator — the same ping-pong ball that the logged-out
+// hero throws around. For page-level loaders we render the auto-spinning
+// 3D ball (Three.js); for tiny inline spinners (button content, sm size,
+// h-4/h-5 sized icons) we fall back to a still ball with rotating ink
+// streaks to avoid spinning up a WebGL context per button.
 const LoadingSpinner = ({ size = 'default', className = '' }) => {
   const px = { sm: 22, default: 36, md: 48, lg: 64 }[size] ?? 36;
 
@@ -12,38 +17,55 @@ const LoadingSpinner = ({ size = 'default', className = '' }) => {
   const hasHeight = /\b(min-h-|h-)\[/.test(className) || /\bmin-h-/.test(className);
   const heightClass = hasHeight ? '' : (size === 'sm' ? '' : 'min-h-[200px]');
 
+  // Detect inline / sized-down usage (e.g. `mr-2 h-4 w-4` inside a button).
+  // For those we skip Three.js — a 16px WebGL canvas is wasteful and the
+  // wordmark texture wouldn't be legible anyway.
+  const isInline = /\b(h|w)-\d+\b/.test(className);
+  const useGL = size !== 'sm' && !isInline;
+
   return (
     <div className={`flex items-center justify-center ${heightClass} ${className}`}>
-      <span
-        className="tt-loading-wrap"
-        style={{ '--tt-loading-size': `${px}px` }}
-        role="status"
-        aria-label="Loading"
-      >
-        {/* Static ball with brand mark on its surface */}
-        <span className="tt-loading-ball-shape">
-          <BrandMark size={Math.round(px * 0.55)} />
-        </span>
-
-        {/* Orbital ink streaks — rotate around the ball perimeter */}
-        <svg
-          className="tt-loading-ink"
-          viewBox="-100 -100 200 200"
-          aria-hidden="true"
-        >
-          <g className="tt-loading-ink-spin">
-            <path d="M 28 -64 A 70 70 0 0 1 60 -36" />
-            <path d="M -62 26 A 67 67 0 0 1 -38 60" strokeOpacity="0.78" />
-            <path d="M -72 -22 A 75 75 0 0 1 -50 -56" strokeOpacity="0.6" strokeWidth="2.2" />
-            <path d="M 64 32 A 71 71 0 0 1 38 64" strokeOpacity="0.55" strokeWidth="2.4" />
-            <circle cx="-18" cy="-78" r="3" fillOpacity="0.78" />
-            <circle cx="80" cy="-6" r="2" fillOpacity="0.6" />
-            <circle cx="14" cy="84" r="2.4" fillOpacity="0.55" />
-          </g>
-        </svg>
-      </span>
+      {useGL ? (
+        <Suspense fallback={<CssBall size={px} />}>
+          <BallLoader size={px} />
+        </Suspense>
+      ) : (
+        <CssBall size={px} />
+      )}
     </div>
   );
 };
+
+// Pure CSS / SVG fallback — a still ping-pong ball with the leagues.lol brand
+// mark on its surface and orbital ink streaks rotating around it.
+function CssBall({ size }) {
+  return (
+    <span
+      className="tt-loading-wrap"
+      style={{ '--tt-loading-size': `${size}px` }}
+      role="status"
+      aria-label="Loading"
+    >
+      <span className="tt-loading-ball-shape">
+        <BrandMark size={Math.round(size * 0.55)} />
+      </span>
+      <svg
+        className="tt-loading-ink"
+        viewBox="-100 -100 200 200"
+        aria-hidden="true"
+      >
+        <g className="tt-loading-ink-spin">
+          <path d="M 28 -64 A 70 70 0 0 1 60 -36" />
+          <path d="M -62 26 A 67 67 0 0 1 -38 60" strokeOpacity="0.78" />
+          <path d="M -72 -22 A 75 75 0 0 1 -50 -56" strokeOpacity="0.6" strokeWidth="2.2" />
+          <path d="M 64 32 A 71 71 0 0 1 38 64" strokeOpacity="0.55" strokeWidth="2.4" />
+          <circle cx="-18" cy="-78" r="3" fillOpacity="0.78" />
+          <circle cx="80" cy="-6" r="2" fillOpacity="0.6" />
+          <circle cx="14" cy="84" r="2.4" fillOpacity="0.55" />
+        </g>
+      </svg>
+    </span>
+  );
+}
 
 export default LoadingSpinner;


### PR DESCRIPTION
Promote the hero ping-pong ball from the logged-out landing page into the
shared loading vocabulary:

- BallLoader: a stripped-down, non-interactive Three.js variant of
  SpinningBall (auto-rotating textured sphere + orbital ink, no drag,
  meter, RPM, or shatter).
- LoadingSpinner now renders BallLoader for page-level uses (lazy-loaded
  so the Three.js chunk only ships when actually needed) and keeps the
  CSS ball as a fallback for sm size and inline button spinners
  (h-4/h-5/etc) where a WebGL context per icon would be wasteful.
- Hoist the 2048x1024 texture builder into ballTexture.js with a
  module-level cache so SpinningBall and every BallLoader instance share
  one canvas + GPU upload.
- index.html ships a CSS-only ball+ink splash inside #root for the very
  first paint, replaced as soon as React mounts so users never see a
  blank/blue browser state.